### PR TITLE
Add skeleton for RISC Zero token bridge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/host/target/
+/guest/target/
+**/Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,2 @@
+[workspace]
+members = ["host", "guest"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# zk Token Bridge Example
+
+This repository provides a minimal example of a token bridge that uses the
+[RISC Zero](https://www.risczero.com) zkVM. It contains two Rust crates:
+
+- `bridge-guest` – the zkVM guest code that verifies a token transfer.
+- `bridge-host` – the host application that runs the guest and verifies the proof.
+
+The guest reads a `Transfer` structure from the host, performs any desired
+checks, and commits the transfer back to the host. The host uses `default_prover`
+from the `risc0-zkvm` crate to produce and verify the proof.
+
+## Building
+
+RISC Zero and its custom target are required to compile the guest. In an offline
+environment, the dependencies may not be available and compilation will fail.
+
+To build (with network access):
+
+```bash
+cargo build --release --workspace
+```
+
+Run the example host binary with:
+
+```bash
+cargo run -p bridge-host
+```

--- a/guest/Cargo.toml
+++ b/guest/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "bridge-guest"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+risc0-zkvm = { version = "0.19", default-features = false }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/guest/src/lib.rs
+++ b/guest/src/lib.rs
@@ -1,0 +1,20 @@
+use risc0_zkvm::guest::env;
+use risc0_zkvm::guest::entry;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+pub struct Transfer {
+    pub from: u64,
+    pub to: u64,
+    pub amount: u64,
+}
+
+#[entry]
+fn main() {
+    // Read the transfer from the host
+    let transfer: Transfer = env::read();
+
+    // In a real bridge we would verify signatures or Merkle proofs here.
+    // For this minimal example we simply echo the transfer back.
+    env::commit(&transfer);
+}

--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "bridge-host"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+risc0-zkvm = "0.19"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+anyhow = "1"
+
+[build-dependencies]
+risc0-build = "0.19"

--- a/host/build.rs
+++ b/host/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    // Build the zkVM guest ELF
+    risc0_build::embed_methods!("../guest");
+}

--- a/host/src/main.rs
+++ b/host/src/main.rs
@@ -1,0 +1,24 @@
+use bridge_guest::{Transfer};
+use risc0_zkvm::{default_prover, ExecutorEnv};
+
+fn main() -> anyhow::Result<()> {
+    // Sample transfer to prove
+    let transfer = Transfer { from: 1, to: 2, amount: 10 };
+
+    // Set up the zkVM execution environment
+    let env = ExecutorEnv::builder()
+        .write(&transfer)
+        .build()?;
+
+    // Run the guest to generate a receipt
+    let receipt = default_prover().prove(env, bridge_guest::ENTRY)?;
+
+    // Verify that the guest committed to the same transfer
+    let verified: Transfer = receipt.journal.decode()?;
+    println!(
+        "Proof verified transfer: {} -> {} amount {}",
+        verified.from, verified.to, verified.amount
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- create workspace with host and guest crates
- implement guest code and host example using RISC Zero zkVM
- document build instructions
- ignore build artifacts

## Testing
- `cargo check --workspace --all-targets --offline` *(fails: could not find crates)*
- `cargo check --workspace --all-targets` *(fails: could not connect to crates.io)*