### PR TITLE
Add beacon header & signature checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/host/target/
+/guest/target/
+**/Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,3 @@
+[workspace]
+resolver = "3"
+members = ["host", "guest"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# zk Token Bridge Example
+
+This repository provides a minimal example of a token bridge that uses the
+[RISC Zero](https://www.risczero.com) zkVM. It contains two Rust crates:
+
+- `bridge-guest` – the zkVM guest code that verifies a token transfer.
+- `bridge-host` – the host application that runs the guest and verifies the proof.
+
+The guest verifies an Ethereum beacon header and an Ed25519 signature on a
+`Transfer` structure. If both checks pass, it commits the transfer back to the
+host. The host uses `default_prover` from the `risc0-zkvm` crate to produce and
+verify the proof.
+
+## Building
+
+RISC Zero and its custom target are required to compile the guest. In an offline
+environment, the dependencies may not be available and compilation will fail.
+
+To build (with network access):
+
+```bash
+cargo build --release --workspace
+```
+
+If the environment lacks network access after setup, the build will fail when
+`cargo` attempts to download dependencies.
+
+Run the example host binary with:
+
+```bash
+cargo run -p bridge-host
+```

--- a/guest/Cargo.toml
+++ b/guest/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "bridge-guest"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+risc0-zkvm = { version = "0.19", default-features = false }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+sha2 = "0.10"
+ed25519-dalek = { version = "1", default-features = false }

--- a/guest/src/lib.rs
+++ b/guest/src/lib.rs
@@ -1,0 +1,65 @@
+use ed25519_dalek::{Signature, VerifyingKey, Verifier};
+use risc0_zkvm::guest::{env, entry};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+#[derive(Serialize, Deserialize)]
+pub struct BeaconHeader {
+    pub slot: u64,
+    pub proposer_index: u64,
+    pub parent_root: [u8; 32],
+    pub state_root: [u8; 32],
+    pub body_root: [u8; 32],
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct Transfer {
+    pub from: u64,
+    pub to: u64,
+    pub amount: u64,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Input {
+    pub beacon: BeaconHeader,
+    pub transfer: Transfer,
+    pub signature: [u8; 64],
+    pub pubkey: [u8; 32],
+    pub expected_root: [u8; 32],
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct VerifiedTransfer {
+    pub root: [u8; 32],
+    pub transfer: Transfer,
+}
+
+#[entry]
+fn main() {
+    let input: Input = env::read();
+
+    // Hash beacon header fields to obtain the root
+    let mut hasher = Sha256::new();
+    hasher.update(&input.beacon.slot.to_le_bytes());
+    hasher.update(&input.beacon.proposer_index.to_le_bytes());
+    hasher.update(&input.beacon.parent_root);
+    hasher.update(&input.beacon.state_root);
+    hasher.update(&input.beacon.body_root);
+    let root: [u8; 32] = hasher.finalize().into();
+
+    if root != input.expected_root {
+        panic!("Beacon header root mismatch");
+    }
+
+    // Verify the transfer signature
+    let vk = VerifyingKey::from_bytes(&input.pubkey).expect("invalid pubkey");
+    let sig = Signature::from_bytes(&input.signature).expect("invalid signature");
+    let transfer_bytes = serde_json::to_vec(&input.transfer).expect("serialize");
+    vk.verify(&transfer_bytes, &sig).expect("signature check failed");
+
+    let verified = VerifiedTransfer {
+        root,
+        transfer: input.transfer,
+    };
+    env::commit(&verified);
+}

--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "bridge-host"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+risc0-zkvm = "0.19"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+anyhow = "1"
+sha2 = "0.10"
+ed25519-dalek = { version = "1", features = ["rand", "serde"] }
+rand = "0.8"
+
+[build-dependencies]
+risc0-build = "0.19"

--- a/host/build.rs
+++ b/host/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    // Build the zkVM guest ELF
+    risc0_build::embed_methods!("../guest");
+}

--- a/host/src/main.rs
+++ b/host/src/main.rs
@@ -1,0 +1,56 @@
+use bridge_guest::{BeaconHeader, Input, Transfer, VerifiedTransfer};
+use ed25519_dalek::{SigningKey, Signer};
+use rand::rngs::OsRng;
+use risc0_zkvm::{default_prover, ExecutorEnv};
+use sha2::{Digest, Sha256};
+
+fn main() -> anyhow::Result<()> {
+    // Sample beacon header
+    let beacon = BeaconHeader {
+        slot: 1,
+        proposer_index: 42,
+        parent_root: [0u8; 32],
+        state_root: [1u8; 32],
+        body_root: [2u8; 32],
+    };
+
+    // Compute expected root
+    let mut hasher = Sha256::new();
+    hasher.update(&beacon.slot.to_le_bytes());
+    hasher.update(&beacon.proposer_index.to_le_bytes());
+    hasher.update(&beacon.parent_root);
+    hasher.update(&beacon.state_root);
+    hasher.update(&beacon.body_root);
+    let expected_root: [u8; 32] = hasher.finalize().into();
+
+    // Transfer to verify
+    let transfer = Transfer { from: 1, to: 2, amount: 10 };
+
+    // Generate signing key and sign the transfer
+    let mut rng = OsRng;
+    let signing_key = SigningKey::generate(&mut rng);
+    let pubkey_bytes: [u8; 32] = signing_key.verifying_key().to_bytes();
+    let transfer_bytes = serde_json::to_vec(&transfer)?;
+    let signature = signing_key.sign(&transfer_bytes).to_bytes();
+
+    let input = Input {
+        beacon,
+        transfer,
+        signature,
+        pubkey: pubkey_bytes,
+        expected_root,
+    };
+
+    let env = ExecutorEnv::builder()
+        .write(&input)
+        .build()?;
+
+    let receipt = default_prover().prove(env, bridge_guest::ENTRY)?;
+    let verified: VerifiedTransfer = receipt.journal.decode()?;
+    println!(
+        "Verified root: {:?}, transfer {} -> {} amount {}",
+        verified.root, verified.transfer.from, verified.transfer.to, verified.transfer.amount
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- verify Ethereum beacon header root and Ed25519 transfer signature
- expose new structures shared between host and guest
- update host example to build input and print verified data
- document verification steps in README

## Testing
- `cargo check --workspace --all-targets --offline` *(fails: no crates found)*
- `cargo check --workspace --all-targets` *(fails: could not connect to crates.io)*